### PR TITLE
Fix error message for missing lib.exe.

### DIFF
--- a/rapidgame.js
+++ b/rapidgame.js
@@ -1439,7 +1439,7 @@ var getLibExePath = function(cb) {
 				logBuild("LIB: " + libExePath, true);
 				cb(true);
 			} else {
-				console.log("Unable to locate lib.exe. Please set the contents of the following file to the absolute path to lib.exe:\n\n\t" + savePath + "\n\nExample: " + bases[0] + names[0]);
+				console.log("Unable to locate lib.exe. Please set the contents of the following file to the absolute path to lib.exe:\n\n\t" + savePath + "\n\nExample: " + bases[0] + names[0] + "lib.exe");
 				cb();
 			}
 		};


### PR DESCRIPTION
If rapidgame can't find lib.exe, it will provide an error message with a helpful example. However, the example doesn't include the `lib.exe` at the end. This proposed change fixes the example.

This fixes #50.